### PR TITLE
Add ContinuousMove soap message

### DIFF
--- a/schema/src/ptz.rs
+++ b/schema/src/ptz.rs
@@ -431,6 +431,8 @@ impl Validate for SetHomePositionResponse {}
     prefix = "tptz",
     namespace = "tptz: http://www.onvif.org/ver20/ptz/wsdl"
 )]
+#[yaserde(prefix = "tt", namespace = "tt: http://www.onvif.org/ver10/schema")]
+
 pub struct ContinuousMove {
     // A reference to the MediaProfile.
     #[yaserde(prefix = "tptz", rename = "ProfileToken")]


### PR DESCRIPTION
ContinuousMove  Soap 메시지에서 아래 부분이 빠져있어서 에러가 발생해서 추가함
#[yaserde(prefix = "tt", namespace = "tt: http://www.onvif.org/ver10/schema")]

디버깅 히스토리 정리
https://www.notion.so/ContinuousMove-history-3e0cd22894484573844ca566000c96c0
