### PR TITLE
Add clone macro for GetDeviceInformationResponse

### DIFF
--- a/schema/src/devicemgmt.rs
+++ b/schema/src/devicemgmt.rs
@@ -370,7 +370,7 @@ pub struct GetDeviceInformation {}
 
 impl Validate for GetDeviceInformation {}
 
-#[derive(Default, PartialEq, Debug, YaSerialize, YaDeserialize)]
+#[derive(Clone, Default, PartialEq, Debug, YaSerialize, YaDeserialize)]
 #[yaserde(
     prefix = "tds",
     namespace = "tds: http://www.onvif.org/ver10/device/wsdl"


### PR DESCRIPTION
Add clone macro for GetDeviceInformationResponse which can be used as message for onvif-client.