### PR TITLE
Update to pass ONVIF client test (incl. http digest)

### DIFF
--- a/onvif/src/soap/auth/digest.rs
+++ b/onvif/src/soap/auth/digest.rs
@@ -55,7 +55,10 @@ impl Digest {
             State::Got401(response) => {
                 let creds = self.creds.as_ref().ok_or(Error::NoCredentials)?;
 
-                request = request.header("Authorization", digest_auth(response, creds, &self.uri)?);
+                request = request.header(
+                    reqwest::header::AUTHORIZATION,
+                    digest_auth(response, creds, &self.uri)?,
+                );
 
                 Ok(request)
             }

--- a/onvif/src/soap/client.rs
+++ b/onvif/src/soap/client.rs
@@ -72,6 +72,7 @@ impl ClientBuilder {
         #[allow(unused_mut)]
         let mut client_builder = reqwest::Client::builder()
             .redirect(reqwest::redirect::Policy::none())
+            .http1_title_case_headers()
             .timeout(self.config.timeout);
 
         #[cfg(feature = "tls")]


### PR DESCRIPTION
- Add http1_title_case_headers to ClientBuilder
- Use pre-defined header key for authorization instead of string