### PR TITLE
Improve discovery stability

### DIFF
--- a/onvif/src/discovery/mod.rs
+++ b/onvif/src/discovery/mod.rs
@@ -200,7 +200,12 @@ fn build_probe() -> probe::Envelope {
             action: "http://schemas.xmlsoap.org/ws/2005/04/discovery/Probe".into(),
             to: "urn:schemas-xmlsoap-org:ws:2005:04:discovery".into(),
         },
-        ..Default::default()
+        body: Body {
+            probe: Probe {
+                types: "dn:NetworkVideoTransmitter".into(),
+                scopes: "".into(),
+            }
+        },
     }
 }
 

--- a/schema/src/ws_discovery.rs
+++ b/schema/src/ws_discovery.rs
@@ -7,6 +7,9 @@ pub mod probe {
     pub struct Probe {
         #[yaserde(prefix = "d", rename = "Types")]
         pub types: String,
+
+        #[yaserde(prefix = "d", rename = "Scopes")]
+        pub scopes: String,
     }
 
     #[derive(Default, PartialEq, Debug, YaSerialize)]
@@ -42,7 +45,8 @@ pub mod probe {
         prefix = "s",
         namespace = "s: http://www.w3.org/2003/05/soap-envelope",
         namespace = "d: http://schemas.xmlsoap.org/ws/2005/04/discovery",
-        namespace = "w: http://schemas.xmlsoap.org/ws/2004/08/addressing"
+        namespace = "w: http://schemas.xmlsoap.org/ws/2004/08/addressing",
+        namespace = "dn: http://www.onvif.org/ver10/network/wsdl"
     )]
     pub struct Envelope {
         #[yaserde(prefix = "s", rename = "Header")]


### PR DESCRIPTION
The body of discover broadcasting message is filled by "dn:NetworkVideoTransmitter" for some IP cameras. 
And output of discovery is filtered not to return duplicated or private IP address.
