### PR TITLE
Update GetStreamUri to use defined struct

### DIFF
--- a/schema/src/media2.rs
+++ b/schema/src/media2.rs
@@ -1110,7 +1110,7 @@ pub struct GetStreamUri {
     // Defines the network protocol for streaming as defined by
     // tr2:TransportProtocol
     #[yaserde(prefix = "tr2", rename = "Protocol")]
-    pub protocol: String,
+    pub protocol: TransportProtocol,
 
     // The ProfileToken element indicates the media profile to use and will
     // define the configuration of the content of the stream.

--- a/schema/src/onvif.rs
+++ b/schema/src/onvif.rs
@@ -2071,7 +2071,7 @@ pub struct Transport {
 
 impl Validate for Transport {}
 
-#[derive(PartialEq, Debug, YaSerialize, YaDeserialize)]
+#[derive(Clone, PartialEq, Debug, YaSerialize, YaDeserialize)]
 #[yaserde(prefix = "tt", namespace = "tt: http://www.onvif.org/ver10/schema")]
 pub enum TransportProtocol {
     #[yaserde(rename = "UDP")]


### PR DESCRIPTION
Update GetStreamUri function to get protocol not as String, but as media2::TransportProtocol which is already defined.
And add clone macro for TransportProtocol.