### PR TITLE
Handling ter:OperationProhibited fault message

### DIFF
--- a/onvif/src/soap/client.rs
+++ b/onvif/src/soap/client.rs
@@ -240,7 +240,7 @@ impl Client {
                 .and_then(|text| {
                     debug!(self, "Response body: {}", text);
                     soap::unsoap(&text).map_err(|e| match e {
-                        soap::Error::Fault(f) if f.is_unauthorized() => {
+                        soap::Error::Fault(f) if f.is_unauthorized() || f.is_prohibited() => {
                             Error::Authorization("Unauthorized".to_string())
                         }
                         _ => Error::Protocol(format!("{:?}", e)),

--- a/schema/src/soap_envelope.rs
+++ b/schema/src/soap_envelope.rs
@@ -75,6 +75,13 @@ impl Fault {
             None => false,
         }
     }
+
+    pub fn is_prohibited(&self) -> bool {
+        match self.code.subcode.as_ref() {
+            Some(subcode) => subcode.value.contains("OperationProhibited"),
+            None => false,
+        }
+    }
 }
 
 impl Validate for Fault {}


### PR DESCRIPTION
In case of AuthType::Any, try other way(WS-UsernameToken) if the ter:OperationProhibited fault message is returned.

Following is example of fault message from device.
```
<SOAP-ENV:Body>
    <SOAP-ENV:Fault>
        <SOAP-ENV:Code>
            <SOAP-ENV:Value>SOAP-ENV:Sender</SOAP-ENV:Value>
            <SOAP-ENV:Subcode>
                <SOAP-ENV:Value>ter:OperationProhibited</SOAP-ENV:Value>
            </SOAP-ENV:Subcode>
        </SOAP-ENV:Code>
        <SOAP-ENV:Reason>
            <SOAP-ENV:Text xml:lang="en">The requested operation is not permitted by the device.</SOAP-ENV:Text>
        </SOAP-ENV:Reason>
    </SOAP-ENV:Fault>
</SOAP-ENV:Body>
```