### PR TITLE
Update discovery function to be stopped by caller

### DIFF
--- a/onvif/examples/discovery.rs
+++ b/onvif/examples/discovery.rs
@@ -1,4 +1,6 @@
 extern crate onvif;
+use std::sync::{Arc, atomic::AtomicBool};
+
 use onvif::discovery;
 
 #[tokio::main]
@@ -9,11 +11,14 @@ async fn main() {
     use futures_util::stream::StreamExt;
     const MAX_CONCURRENT_JUMPERS: usize = 100;
 
-    discovery::discover(std::time::Duration::from_secs(3))
-        .await
-        .unwrap()
-        .for_each_concurrent(MAX_CONCURRENT_JUMPERS, |addr| async move {
-            println!("Device found: {addr:?}");
-        })
-        .await;
+    discovery::discover(
+        std::time::Duration::from_secs(3),
+        Arc::new(AtomicBool::new(false)),
+    )
+    .await
+    .unwrap()
+    .for_each_concurrent(MAX_CONCURRENT_JUMPERS, |addr| async move {
+        println!("Device found: {addr:?}");
+    })
+    .await;
 }


### PR DESCRIPTION
By this patch, user can stop discovery function by sending AtomicBool(true)