### PR TITLE
Fix event synchronization point error

### DIFF
--- a/onvif/examples/discovery.rs
+++ b/onvif/examples/discovery.rs
@@ -1,5 +1,5 @@
 extern crate onvif;
-use std::sync::{Arc, atomic::AtomicBool};
+use std::sync::{atomic::AtomicBool, Arc};
 
 use onvif::discovery;
 


### PR DESCRIPTION
## Purpose
<!-- (put an "X" next to an item) -->

- [ ] New Feature
- [ ] Refactoring
- [X] Bug fix
- [ ] Other

## Changes
<!-- Insert descriptions of your changes -->
- Pull point subscription 응답의 endpoint address가 루프백인 경우 Client Config의 url로 대체한다